### PR TITLE
Update Post_ImportRaster.py to allow for auto tiling

### DIFF
--- a/processing_provider/Post_ImportRaster.py
+++ b/processing_provider/Post_ImportRaster.py
@@ -286,6 +286,8 @@ class ImportRaster(QgsProcessingAlgorithm):
         )
         if len(tiling)>2 and 'x' in tiling:
             tiling = '-t {} '.format(tiling)
+        elif tiling == 'auto':
+            tiling = '-t auto '		
         else:
             tiling = ''
 


### PR DESCRIPTION
Small change to allow for auto tiling option.

`-t TILE_SIZE`
Cut raster into tiles to be inserted one per table row. TILE_SIZE is expressed as WIDTHxHEIGHT **or set to the value "auto" to allow the loader to compute an appropriate tile size using the first raster and applied to all rasters.**

https://postgis.net/docs/using_raster_dataman.html